### PR TITLE
Detects class components that don't use JSX & only reports on identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ class TimerComponent extends React.Component {
     null;
   }
 }
+```
+Thanks @wo1ph for the improvements!
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ class TimerComponent extends React.Component {
     null;
   }
 }
-```
 
 ## v2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v3.0.0
+
+Detects `class` components that extend the `Component` class, even if they do not use any JSX. Now errors on manager, business logic, and other renderless `class` components that extend `Component`. Previously the below was not caught:
+
+```jsx
+class TimerComponent extends React.Component {
+  /// ...
+
+  componentWillMount() {
+    this.startTimer();
+  }
+
+  componentWillUnmount() {
+    this.stopTimer();
+  }
+
+  render() {
+    null;
+  }
+}
+```
+
 ## v2.0.0
 
 Support for `createClass` has been dropped. Usage of `createClass` will no longer be detected.

--- a/public.package.json
+++ b/public.package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-react-prefer-function-component",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "ESLint plugin that prevents the use of JSX class components",
   "license": "MIT",
   "author": "Tate <tatethurston@gmail.com>",

--- a/src/prefer-function-component/index.ts
+++ b/src/prefer-function-component/index.ts
@@ -9,6 +9,7 @@ export const ALLOW_COMPONENT_DID_CATCH = "allowComponentDidCatch";
 const COMPONENT_DID_CATCH = "componentDidCatch";
 // https://eslint.org/docs/developer-guide/working-with-rules
 const PROGRAM_EXIT = "Program:exit";
+const VARIABLE_DECLARATOR = "VariableDeclarator";
 
 // TODO: Type definitions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,6 +85,15 @@ const rule: Rule.RuleModule = {
       "ClassExpression[superClass.name='Component']": detect,
       [PROGRAM_EXIT]() {
         components.forEach((node) => {
+          // report on just the class identifier
+          if (node.id) {
+            // for ClassDeclaration
+            node = node.id;
+          } else if (node.parent.type == VARIABLE_DECLARATOR) {
+            //for ClassExpression
+            node = node.parent.id;
+          }
+
           context.report({
             node,
             messageId: COMPONENT_SHOULD_BE_FUNCTION,

--- a/src/prefer-function-component/index.ts
+++ b/src/prefer-function-component/index.ts
@@ -9,7 +9,6 @@ export const ALLOW_COMPONENT_DID_CATCH = "allowComponentDidCatch";
 const COMPONENT_DID_CATCH = "componentDidCatch";
 // https://eslint.org/docs/developer-guide/working-with-rules
 const PROGRAM_EXIT = "Program:exit";
-const VARIABLE_DECLARATOR = "VariableDeclarator";
 
 // TODO: Type definitions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/prefer-function-component/index.ts
+++ b/src/prefer-function-component/index.ts
@@ -9,6 +9,7 @@ export const ALLOW_COMPONENT_DID_CATCH = "allowComponentDidCatch";
 const COMPONENT_DID_CATCH = "componentDidCatch";
 // https://eslint.org/docs/developer-guide/working-with-rules
 const PROGRAM_EXIT = "Program:exit";
+const VARIABLE_DECLARATOR = "VariableDeclarator";
 
 // TODO: Type definitions
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,9 +75,14 @@ const rule: Rule.RuleModule = {
     return {
       "ClassDeclaration:has(JSXElement)": detect,
       "ClassDeclaration:has(JSXFragment)": detect,
+      "ClassDeclaration[superClass.object.name='React'][superClass.property.name='Component']":
+        detect,
+      "ClassDeclaration[superClass.name='Component']": detect,
       "ClassExpression:has(JSXElement)": detect,
       "ClassExpression:has(JSXFragment)": detect,
-
+      "ClassExpression[superClass.object.name='React'][superClass.property.name='Component']":
+        detect,
+      "ClassExpression[superClass.name='Component']": detect,
       [PROGRAM_EXIT]() {
         components.forEach((node) => {
           context.report({

--- a/src/prefer-function-component/test.ts
+++ b/src/prefer-function-component/test.ts
@@ -267,5 +267,70 @@ ruleTester.run("prefer-function-component", rule, {
         },
       ],
     },
+    {
+      // Does not contain JSX and extends React.Component.
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return null;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: COMPONENT_SHOULD_BE_FUNCTION,
+        },
+      ],
+    },
+
+    {
+      // Does not contain JSX and extends Component.
+      code: `
+        import { Component } from 'react';
+
+        class Foo extends Component {
+          render() {
+            return null;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: COMPONENT_SHOULD_BE_FUNCTION,
+        },
+      ],
+    },
+    {
+      // Does not contain JSX and extends React.Component in an expression context.
+      code: `
+        const Foo = class extends React.Component {
+          render() {
+            return null;
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: COMPONENT_SHOULD_BE_FUNCTION,
+        },
+      ],
+    },
+    {
+      // Does not contain JSX and extends Component in an expression context.
+      code: `
+        import { Component } from 'react';
+
+        const Foo = class extends Component {
+          render() {
+            return null;
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: COMPONENT_SHOULD_BE_FUNCTION,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
This PR adds detecting class components that do not use any JSX like manager, business logic, and other renderless class components. Previously components like this would not be caught:

```jsx
class TimerComponent extends React.Component {
  /// ...

  componentWillMount() {
    this.startTimer();
  }

  componentWillUnmount() {
    this.stopTimer();
  }

  render() {
    null;
  }
}
```

Now, it will error on any class components that extend the `Component` class.

Also, this PR adds reporting on only the identifier of the class --- rather than reporting the entire declaration/expression, to reduce reporting noise in the editor.