### PR TITLE
update test suite to run all by all for options

### DIFF
--- a/src/prefer-function-component/index.ts
+++ b/src/prefer-function-component/index.ts
@@ -54,8 +54,8 @@ const rule: Rule.RuleModule = {
   create(context: Rule.RuleContext) {
     const allowComponentDidCatch =
       context.options[0]?.allowComponentDidCatch ?? true;
-    const allowJsxInClasses =
-      context.options[0]?.allowComponentDidCatch ?? false;
+    // const allowJsxInClasses =
+    //   context.options[0]?.allowComponentDidCatch ?? false;
 
     function shouldPreferFunction(node: Node): boolean {
       const properties = node.body.body;
@@ -79,20 +79,20 @@ const rule: Rule.RuleModule = {
       }
     }
 
-    function detectJsxInClass(node: Node): void {
-      if (!allowJsxInClasses) {
-        detect(node);
-      }
-    }
+    // function detectJsxInClass(node: Node): void {
+    //   if (!allowJsxInClasses) {
+    //     detect(node);
+    //   }
+    // }
 
     return {
-      "ClassDeclaration:has(JSXElement)": detectJsxInClass,
-      "ClassDeclaration:has(JSXFragment)": detectJsxInClass,
+      "ClassDeclaration:has(JSXElement)": detect,
+      "ClassDeclaration:has(JSXFragment)": detect,
       "ClassDeclaration[superClass.object.name='React'][superClass.property.name='Component']":
         detect,
       "ClassDeclaration[superClass.name='Component']": detect,
-      "ClassExpression:has(JSXElement)": detectJsxInClass,
-      "ClassExpression:has(JSXFragment)": detectJsxInClass,
+      "ClassExpression:has(JSXElement)": detect,
+      "ClassExpression:has(JSXFragment)": detect,
       "ClassExpression[superClass.object.name='React'][superClass.property.name='Component']":
         detect,
       "ClassExpression[superClass.name='Component']": detect,

--- a/src/prefer-function-component/test.ts
+++ b/src/prefer-function-component/test.ts
@@ -15,217 +15,224 @@ const ruleTester = new RuleTester({
   },
 });
 
+const validForAllOptions = [
+  // Already a stateless function
+  `\
+    const Foo = function(props) {
+      return <div>{props.foo}</div>;
+    };
+  `,
+  // Already a stateless (arrow) function
+  "const Foo = ({foo}) => <div>{foo}</div>;",
+  // class without JSX
+  `\
+    class Foo {
+      render() {
+        return 'hello'
+      }
+    };
+  `,
+  // object with JSX
+  `\
+    const foo = {
+      foo: <h>hello</h>
+    };
+  `,
+];
+
+const invalidForAllOptions = [
+  // Extending from react
+  `\
+    import { Component } from 'react';
+
+    class Foo extends Component {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  // Extending from preact
+  `\
+    import { Component } from 'preact';
+
+    class Foo extends Component {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  // Extending from inferno
+  `\
+    import { Component } from 'inferno';
+
+    class Foo extends Component {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  // Extending from another class (not Component)
+  `\
+    import Document from 'next/document';
+
+    class Foo extends Document {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  `\
+    class Foo extends React.Component {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  `\
+    class Foo extends React.PureComponent {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  `\
+    const Foo = class extends React.Component {
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    };
+  `,
+  // Does not contain JSX and extends React.Component.
+  `\
+    class Foo extends React.Component {
+      render() {
+        return null;
+      }
+    }
+  `,
+  // Does not contain JSX and extends Component.
+  `\
+    import { Component } from 'react';
+
+    class Foo extends Component {
+      render() {
+        return null;
+      }
+    }
+  `,
+  // Does not contain JSX and extends React.Component in an expression context.
+  `\
+    const Foo = class extends React.Component {
+      render() {
+        return null;
+      }
+    };
+  `,
+  // Does not contain JSX and extends Component in an expression context.
+  `\
+    import { Component } from 'react';
+
+    const Foo = class extends Component {
+      render() {
+        return null;
+      }
+    };
+  `,
+];
+
+const componentDidCatch = [
+  // Extends from Component and uses componentDidCatch
+  `\
+    class Foo extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        logErrorToMyService(error, errorInfo);
+      }
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  // Extends from Component and uses componentDidCatch
+  `\
+    class Foo extends React.PureComponent {
+      componentDidCatch(error, errorInfo) {
+        logErrorToMyService(error, errorInfo);
+      }
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    }
+  `,
+  // Extends from Component in an expression context.
+  `\
+    const Foo = class extends React.Component {
+      componentDidCatch(error, errorInfo) {
+        logErrorToMyService(error, errorInfo);
+      }
+      render() {
+        return <div>{this.props.foo}</div>;
+      }
+    };
+  `,
+];
+
 ruleTester.run("prefer-function-component", rule, {
   valid: [
-    {
-      // Already a stateless function
-      code: `
-        const Foo = function(props) {
-          return <div>{props.foo}</div>;
-        };
-      `,
-    },
-    {
-      // Already a stateless (arrow) function
-      code: "const Foo = ({foo}) => <div>{foo}</div>;",
-    },
-    {
-      // Extends from Component and uses componentDidCatch
-      code: `
-        class Foo extends React.Component {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-    },
-    {
-      // Extends from Component and uses componentDidCatch
-      code: `
-        class Foo extends React.PureComponent {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-    },
-    {
-      // Extends from Component in an expression context.
-      code: `
-        const Foo = class extends React.Component {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        };
-      `,
-    },
-    {
-      // class without JSX
-      code: `
-        class Foo {
-          render() {
-            return 'hello'
-          }
-        };
-      `,
-    },
-    {
-      // non-component class with JSX
-      code: `
-        class Foo {
-          getBar() {
-            return <Bar />;
-          }
-        };
-      `,
-      options: [
-        {
-          [ALLOW_JSX_IN_CLASSES]: true,
-        },
-      ],
-    },
-    {
-      // object with JSX
-      code: `
-        const foo = {
-          foo: <h>hello</h>
-        };
-      `,
-    },
+    ...validForAllOptions.flatMap((code) => [
+      { code },
+      { code, options: [{ [ALLOW_JSX_IN_CLASSES]: true }] },
+      { code, options: [{ [ALLOW_COMPONENT_DID_CATCH]: true }] },
+      {
+        code,
+        options: [
+          { [ALLOW_JSX_IN_CLASSES]: true, [ALLOW_COMPONENT_DID_CATCH]: true },
+        ],
+      },
+    ]),
+    ...componentDidCatch.flatMap((code) => [
+      { code },
+      { code, options: [{ [ALLOW_JSX_IN_CLASSES]: true }] },
+    ]),
+    // {
+    //   // non-component class with JSX
+    //   code: `
+    //     class Foo {
+    //       getBar() {
+    //         return <Bar />;
+    //       }
+    //     };
+    //   `,
+    //   options: [
+    //     {
+    //       [ALLOW_JSX_IN_CLASSES]: true,
+    //     },
+    //   ],
+    // },
   ],
 
   invalid: [
-    // Extending from react
-    {
-      code: `
-        import { Component } from 'react';
-
-        class Foo extends Component {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    // Extending from preact
-    {
-      code: `
-        import { Component } from 'preact';
-
-        class Foo extends Component {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    // Extending from inferno
-    {
-      code: `
-        import { Component } from 'inferno';
-
-        class Foo extends Component {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    // Extending from another class (not Component)
-    {
-      code: `
-        import Document from 'next/document';
-
-        class Foo extends Document {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      code: `
-        class Foo extends React.Component {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      code: `
-        class Foo extends React.PureComponent {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      code: `
-        const Foo = class extends React.Component {
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        };
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      // Extends from Component and uses componentDidCatch
-      code: `
-        class Foo extends React.Component {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
+    ...invalidForAllOptions.flatMap((code) => [
+      { code, errors: [{ messageId: COMPONENT_SHOULD_BE_FUNCTION }] },
+      {
+        code,
+        errors: [{ messageId: COMPONENT_SHOULD_BE_FUNCTION }],
+        options: [{ [ALLOW_JSX_IN_CLASSES]: true }],
+      },
+      {
+        code,
+        errors: [{ messageId: COMPONENT_SHOULD_BE_FUNCTION }],
+        options: [{ [ALLOW_COMPONENT_DID_CATCH]: true }],
+      },
+      {
+        code,
+        errors: [{ messageId: COMPONENT_SHOULD_BE_FUNCTION }],
+        options: [
+          { [ALLOW_JSX_IN_CLASSES]: true, [ALLOW_COMPONENT_DID_CATCH]: true },
+        ],
+      },
+    ]),
+    ...componentDidCatch.map((code) => ({
+      code,
       options: [
         {
           [ALLOW_COMPONENT_DID_CATCH]: false,
@@ -236,117 +243,6 @@ ruleTester.run("prefer-function-component", rule, {
           messageId: COMPONENT_SHOULD_BE_FUNCTION,
         },
       ],
-    },
-    {
-      // Extends from Component and uses componentDidCatch
-      code: `
-        class Foo extends React.PureComponent {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        }
-      `,
-      options: [
-        {
-          [ALLOW_COMPONENT_DID_CATCH]: false,
-        },
-      ],
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      // Extends from Component in an expression context.
-      code: `
-        const Foo = class extends React.Component {
-          componentDidCatch(error, errorInfo) {
-            logErrorToMyService(error, errorInfo);
-          }
-          render() {
-            return <div>{this.props.foo}</div>;
-          }
-        };
-      `,
-      options: [
-        {
-          [ALLOW_COMPONENT_DID_CATCH]: false,
-        },
-      ],
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      // Does not contain JSX and extends React.Component.
-      code: `
-        class Foo extends React.Component {
-          render() {
-            return null;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-
-    {
-      // Does not contain JSX and extends Component.
-      code: `
-        import { Component } from 'react';
-
-        class Foo extends Component {
-          render() {
-            return null;
-          }
-        }
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      // Does not contain JSX and extends React.Component in an expression context.
-      code: `
-        const Foo = class extends React.Component {
-          render() {
-            return null;
-          }
-        };
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
-    {
-      // Does not contain JSX and extends Component in an expression context.
-      code: `
-        import { Component } from 'react';
-
-        const Foo = class extends Component {
-          render() {
-            return null;
-          }
-        };
-      `,
-      errors: [
-        {
-          messageId: COMPONENT_SHOULD_BE_FUNCTION,
-        },
-      ],
-    },
+    })),
   ],
 });


### PR DESCRIPTION
@noahm I'm temporarily reverting #10 because the componentDidCatch configuration option stopped working after introducing it. This test suite upgrade catches the regression. I'll follow up on #10 after this.