### PR TITLE
fix flat config types

### DIFF
--- a/packages/eslint-plugin-react-prefer-function-component/src/config.mts
+++ b/packages/eslint-plugin-react-prefer-function-component/src/config.mts
@@ -7,7 +7,7 @@ const plugin: ESLint.Plugin = {
   },
 };
 
-const config: ESLint.Plugin = {
+const config = {
   configs: {
     recommended: {
       plugins: {
@@ -18,6 +18,6 @@ const config: ESLint.Plugin = {
       },
     },
   },
-};
+} satisfies ESLint.Plugin;
 
 export default config;


### PR DESCRIPTION
Hey, I just noticed that the types of the flat config are currently lacking in specificity, resulting in IDEs not being able to provide auto complete suggestions and showing a warning:

```ts
const preferFC = require("eslint-plugin-react-prefer-function-component/config")

module.exports = [
  preferFC.configs.recommended
  //       ^^^ Unresolved variable configs
]
```

This could be fixed by using the [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html) keyword of typescript instead of explicitly setting the type.

With this change, typescript will be able to keep the most specific version of the type and the IDE will be able to show suggestions.

Before:
![image](https://github.com/user-attachments/assets/b8a699c1-39b4-47c7-b3a4-919ad0a4a25a)

After:
![image](https://github.com/user-attachments/assets/83ebecf8-8578-4387-a142-911ab9bbe3f8)

Thanks a lot for the plugin btw! :)