### PR TITLE
Add `react-` prefix to flat configuration rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const Foo = ({ foo }) => <div>{foo}</div>;
 
 ```js
 ...
-"prefer-function-component": [<enabled>, { "allowComponentDidCatch": <allowComponentDidCatch>, "allowJsxUtilityClass": <allowJsxUtilityClass> }]
+"react-prefer-function-component": [<enabled>, { "allowComponentDidCatch": <allowComponentDidCatch>, "allowJsxUtilityClass": <allowJsxUtilityClass> }]
 ...
 ```
 

--- a/packages/eslint-plugin-react-prefer-function-component/src/config.mts
+++ b/packages/eslint-plugin-react-prefer-function-component/src/config.mts
@@ -3,7 +3,7 @@ import preferFunctionComponent from "./prefer-function-component/index.js";
 
 const plugin: ESLint.Plugin = {
   rules: {
-    "prefer-function-component": preferFunctionComponent.default,
+    "react-prefer-function-component": preferFunctionComponent.default,
   },
 };
 
@@ -11,10 +11,10 @@ const config = {
   configs: {
     recommended: {
       plugins: {
-        "prefer-function-component": plugin,
+        "react-prefer-function-component": plugin,
       },
       rules: {
-        "prefer-function-component/prefer-function-component": "error",
+        "react-prefer-function-component/prefer-function-component": "error",
       },
     },
   },


### PR DESCRIPTION
For consistency with the legacy configuration and to ease the migration to ESLint 9, it feels reasonable to keep the same rule name across the plugin.